### PR TITLE
Support for chrome-for-testing

### DIFF
--- a/autoselenium/download.py
+++ b/autoselenium/download.py
@@ -14,8 +14,8 @@ def download_driver(driver, version='current', root='.'):
     if not os.path.exists(root):
         os.mkdir(root)
 
-    driver_name = get_driver_name(driver)
-    driver_path = root + f'/{driver_name}driver' + ('.exe' if platform == 'win32' else '')
+    driver_folder = f'{root}/{driver}'
+    driver_path = driver_folder + f'/{driver}driver' + ('.exe' if platform == 'win32' else '')
     driver_path = Path(driver_path).absolute()
 
     if driver_path.exists():
@@ -24,9 +24,9 @@ def download_driver(driver, version='current', root='.'):
         version = get_version(driver, version)
         url, filename = gen_url(driver, version)
         download_url(url, filename)
-        extract(filename, root)
+        extract(filename, driver_folder)
         fix_paths(driver, driver_path)
-        assert driver_path.exists(), driver_path
+        assert driver_path.exists()
 
     except (HTTPError, URLError):
         raise RuntimeError(f'Cannot download {driver} driver.\n'
@@ -44,7 +44,8 @@ def get_version(driver, version):
         return get_latest_version(driver)
     elif version == 'current':
         return get_current_version(driver)
-    return parse_version(driver, version)
+    else:
+        return parse_version(driver, version)
 
 
 def parse_version(driver, raw_version):
@@ -53,7 +54,8 @@ def parse_version(driver, raw_version):
         return 'v' + raw_version
     elif driver == 'opera':
         return 'v.' + raw_version
-    return raw_version
+    else:
+        return raw_version
 
 
 def download_url(url, filename):
@@ -67,16 +69,15 @@ def extract(filename, tgt_path):
 
 
 def fix_paths(driver, driver_path):
-    if driver in ['chrome', 'brave']:
-        os.remove(driver_path.parent / 'LICENSE.chromedriver')
+    src_path = search_driver(root=driver_path.parent)
+    if driver in ['chrome', 'firefox', 'brave', 'edge']:
+        os.rename(src_path, driver_path)      # rename for convenience
+        if driver == 'edge':
+            shutil.rmtree(f'{driver_path.parent}/Driver_Notes')
 
     elif driver == 'opera':
-        src_path = search_driver(browser=driver, root=driver_path.parent)
         shutil.move(src_path, driver_path)  # moves driver and deletes extra dir
         shutil.rmtree(src_path.parent)
-
-    elif driver == 'edge':
-        shutil.rmtree(driver_path.parent / 'Driver_Notes')
 
     if platform in ['linux', 'darwin'] and driver in ['chrome', 'opera', 'brave']:
         os.chmod(driver_path, 755)  # add permissions for linux/mac drivers


### PR DESCRIPTION
Latest versions of chrome has to be downloaded via chrome-for-testing: https://chromedriver.chromium.org/downloads

Latest stable release of chrome could not be downloaded from https://chromedriver.chromium.org/ and not listed (e.g. https://chromedriver.storage.googleapis.com/LATEST_RELEASE_115)

Instead, stable and newer releases should be checked from chrome-for-testing API such as https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json (See: https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints), then downloaded from url that looks like 	https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.170/win64/chrome-win64.zip

Note that this PR is a bit messy (e.g. adding '-chrome-for-testing' to the end of version number to mark that the version of chrome has to be downloaded from chrome-for-testing). but it works. See if you want to change the structure of your code such that my dirty hack is not needed.